### PR TITLE
search/suggestions: Allow use of Google SettingsIntelligence

### DIFF
--- a/src/com/android/settings/dashboard/DashboardSummary.java
+++ b/src/com/android/settings/dashboard/DashboardSummary.java
@@ -92,7 +92,7 @@ public class DashboardSummary extends InstrumentedFragment
         if (suggestionFeatureProvider.isSuggestionEnabled(context)) {
             mSuggestionControllerMixin = new SuggestionControllerMixin(context, this /* host */,
                     getLifecycle(), suggestionFeatureProvider
-                    .getSuggestionServiceComponent());
+                    .getSuggestionServiceComponent(context));
         }
     }
 

--- a/src/com/android/settings/dashboard/suggestions/SuggestionFeatureProvider.java
+++ b/src/com/android/settings/dashboard/suggestions/SuggestionFeatureProvider.java
@@ -39,7 +39,7 @@ public interface SuggestionFeatureProvider {
     /**
      * Returns the component name for SuggestionService.
      */
-    ComponentName getSuggestionServiceComponent();
+    ComponentName getSuggestionServiceComponent(Context context);
 
     /**
      * Returns true if smart suggestion should be used instead of xml based SuggestionParser.

--- a/src/com/android/settings/dashboard/suggestions/SuggestionFeatureProviderImpl.java
+++ b/src/com/android/settings/dashboard/suggestions/SuggestionFeatureProviderImpl.java
@@ -44,6 +44,7 @@ import com.android.settingslib.drawer.Tile;
 import com.android.settingslib.suggestions.SuggestionControllerMixin;
 
 import java.util.List;
+import java.lang.String;
 
 public class SuggestionFeatureProviderImpl implements SuggestionFeatureProvider {
 
@@ -64,10 +65,19 @@ public class SuggestionFeatureProviderImpl implements SuggestionFeatureProvider 
     }
 
     @Override
-    public ComponentName getSuggestionServiceComponent() {
-        return new ComponentName(
-                "com.android.settings.intelligence",
-                "com.android.settings.intelligence.suggestions.SuggestionService");
+    public ComponentName getSuggestionServiceComponent(Context context) {
+        String intelligencePkg = FeatureFactory.getFactory(context)
+                                               .getSearchFeatureProvider()
+                                               .getSettingsIntelligencePkgName(context);
+
+        StringBuilder intelligence = new StringBuilder(intelligencePkg);
+        String serviceBase = intelligencePkg.contains("google") ?
+                                    ".modules" : "";
+        String suggestionService = intelligence.append(serviceBase)
+                                               .append(".suggestions.SuggestionService")
+                                               .toString();
+
+        return new ComponentName(intelligencePkg, suggestionService);
     }
 
     @Override

--- a/src/com/android/settings/search/SearchFeatureProvider.java
+++ b/src/com/android/settings/search/SearchFeatureProvider.java
@@ -53,7 +53,7 @@ public interface SearchFeatureProvider {
      */
     SearchIndexableResources getSearchIndexableResources();
 
-    default String getSettingsIntelligencePkgName() {
+    default String getSettingsIntelligencePkgName(Context context) {
         return "com.android.settings.intelligence";
     }
 
@@ -66,7 +66,7 @@ public interface SearchFeatureProvider {
         }
         toolbar.setOnClickListener(tb -> {
             final Intent intent = SEARCH_UI_INTENT;
-            intent.setPackage(getSettingsIntelligencePkgName());
+            intent.setPackage(getSettingsIntelligencePkgName(activity.getApplicationContext()));
 
             FeatureFactory.getFactory(
                     activity.getApplicationContext()).getSlicesFeatureProvider()

--- a/src/com/android/settings/search/SearchFeatureProviderImpl.java
+++ b/src/com/android/settings/search/SearchFeatureProviderImpl.java
@@ -19,6 +19,9 @@ package com.android.settings.search;
 
 import android.content.ComponentName;
 import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import android.text.TextUtils;
 
 import com.android.internal.annotations.VisibleForTesting;
@@ -47,7 +50,7 @@ public class SearchFeatureProviderImpl implements SearchFeatureProvider {
         }
         final String packageName = caller.getPackageName();
         final boolean isSettingsPackage = TextUtils.equals(packageName, context.getPackageName())
-                || TextUtils.equals(getSettingsIntelligencePkgName(), packageName);
+                || TextUtils.equals(getSettingsIntelligencePkgName(context), packageName);
         final boolean isWhitelistedPackage =
                 isSignatureWhitelisted(context, caller.getPackageName());
         if (isSettingsPackage || isWhitelistedPackage) {
@@ -100,5 +103,26 @@ public class SearchFeatureProviderImpl implements SearchFeatureProvider {
             query = IndexData.normalizeJapaneseString(query);
         }
         return query.trim();
+    }
+
+    @Override
+    public String getSettingsIntelligencePkgName(Context context) {
+        String googleIntelligence = "com.google.android.settings.intelligence";
+        String aospIntelligence = "com.android.settings.intelligence";
+        boolean useGoogle = false;
+
+        // Check if Google SettingIntelligence is available
+        try {
+            useGoogle = context.getPackageManager().getPackageInfo(googleIntelligence,
+                            PackageManager.MATCH_DISABLED_COMPONENTS).applicationInfo.enabled;
+        }
+        catch (PackageManager.NameNotFoundException nameNotFoundException) {
+            return aospIntelligence;
+        }
+
+        // Return the correct Settings Intelligence package
+        if (useGoogle)
+            return googleIntelligence;
+        return aospIntelligence;
     }
 }

--- a/src/com/android/settings/search/actionbar/SearchMenuController.java
+++ b/src/com/android/settings/search/actionbar/SearchMenuController.java
@@ -71,7 +71,7 @@ public class SearchMenuController implements LifecycleObserver, OnCreateOptionsM
         searchItem.setOnMenuItemClickListener(target -> {
             final Intent intent = SearchFeatureProvider.SEARCH_UI_INTENT;
             intent.setPackage(FeatureFactory.getFactory(mHost.getContext())
-                    .getSearchFeatureProvider().getSettingsIntelligencePkgName());
+                    .getSearchFeatureProvider().getSettingsIntelligencePkgName(mHost.getContext()));
 
             mHost.startActivityForResult(intent, 0 /* requestCode */);
             return true;


### PR DESCRIPTION
this commit was previously commited to repo. It fixed settings forcing closing on taimen device with gapps installed when using the search feature in settings. It was reverted in squashed revert ae169c93444fa1d8ca2f9e4080cbe5475b9350d0. Builds after the revert force closed when searching settings again. I forked settings repo and cherry-picked again. Now settings search works fine when using forked repo. Battery stats seems to be fine when using the forked repo